### PR TITLE
Update for 1.6 Vanilla Expanded Framework namespace change

### DIFF
--- a/Source/AnimalGenetics/HarmonyPatches/Comp_ResourceAmount.cs
+++ b/Source/AnimalGenetics/HarmonyPatches/Comp_ResourceAmount.cs
@@ -21,7 +21,7 @@ public static class Comp_ResourceAmount
         }
 
         Log.Message("[AnimalGenetics]: Added patch for CompAnimalProduct in Vanilla Expanded Framework");
-        yield return AccessTools.Method("AnimalBehaviours.CompAnimalProduct:get_ResourceAmount");
+        yield return AccessTools.Method("VEF.AnimalBehaviours.CompAnimalProduct:get_ResourceAmount");
     }
 
     public static void Postfix(ref int __result, CompHasGatherableBodyResource __instance)


### PR DESCRIPTION
Sorry, C# isn't my language.

There's a conflict when I initialize this with Vanilla Extended Framework on 1.6.  It happens whether this is before or after VEF in the modlist.

Error here:
Error in static constructor of AnimalGenetics.HarmonyPatches.AnimalGeneticsAssemblyLoader: System.TypeInitializationException: The type initializer for 'AnimalGenetics.HarmonyPatches.AnimalGeneticsAssemblyLoader' threw an exception. ---> HarmonyLib.HarmonyException: Patching exception in method null ---> System.Exception: Method static System.Collections.Generic.IEnumerable`1<System.Reflection.MethodBase> AnimalGenetics.HarmonyPatches.Comp_ResourceAmount::TargetMethods() returned an unexpected result: some element was null
[Ref FD4E4F1A]

I think this is the cause: https://github.com/Vanilla-Expanded/VanillaExpandedFramework/wiki/16Changes#animal-behaviours

IDK much about how Rimworld mods are built/published, but this is one of my favorite mods so I had to have it before 1.6 came out.